### PR TITLE
Remove .NET 8 Upgrade Code Ahead of Maintenance Window

### DIFF
--- a/restitution-app/ClientApp/package-lock.json
+++ b/restitution-app/ClientApp/package-lock.json
@@ -8099,6 +8099,21 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
+    "moment-timezone": {
+      "version": "0.5.46",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
+      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+      "requires": {
+        "moment": "^2.29.4"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.30.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+          "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/restitution-app/ClientApp/package.json
+++ b/restitution-app/ClientApp/package.json
@@ -46,6 +46,7 @@
     "jasmine-reporters": "^2.4.0",
     "jasmine2-protractor-utils": "^1.3.0",
     "moment": "^2.22.2",
+    "moment-timezone": "^0.5.46",
     "mygovbc-bootstrap-theme": "^0.4.1",
     "ng-busy": "^7.0.0",
     "ngx-bootstrap": "^3.0.0",

--- a/restitution-app/ClientApp/src/app/app.component.html
+++ b/restitution-app/ClientApp/src/app/app.component.html
@@ -18,6 +18,14 @@
     <div>
         <main class="app-content">
             <div class="app-main">
+              <div
+                *ngIf="!error && isOutage()"
+                class="text-center warning"
+              >
+                <h1 class="warning">Site Outage</h1>
+                <h2 class="warning"><b>{{ configuration.outageMessage }}</b></h2>
+                <h2 class="warning"><b>{{ generateOutageDateMessage() }}</b></h2>
+              </div>
                 <breadcrumb></breadcrumb>
                 <router-outlet></router-outlet>
             </div>

--- a/restitution-app/ClientApp/src/app/app.component.scss
+++ b/restitution-app/ClientApp/src/app/app.component.scss
@@ -8,6 +8,10 @@ header {
   border-bottom: 4px solid #fcba19;
 }
 
+.warning{
+  color: red !important;
+}
+
 .title {
   font-weight: Semi-bold;
   font-size: 30px;

--- a/restitution-app/ClientApp/src/app/interfaces/configuration.interface.ts
+++ b/restitution-app/ClientApp/src/app/interfaces/configuration.interface.ts
@@ -1,0 +1,5 @@
+export interface Configuration {
+  outageStartDate?: string;
+  outageEndDate?: string;
+  outageMessage?: string;
+}

--- a/restitution-app/ClientApp/src/app/services/config.service.ts
+++ b/restitution-app/ClientApp/src/app/services/config.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { Configuration } from '../interfaces/configuration.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService{
+  headers: HttpHeaders = new HttpHeaders({
+    'Content-Type': 'application/json'
+  });
+  apiUrl = 'api/Configuration';
+
+  constructor(
+    private http: HttpClient,
+  ) { }
+
+  public async load(): Promise<Configuration> {
+    try {
+      return await
+        this.http.get<Configuration>(this.apiUrl, { headers: this.headers })
+          .pipe(catchError(this.handleError)).toPromise();
+    } catch (error) {
+      this.handleError(error);
+      throw error;
+    }
+  }
+
+  protected handleError(err): Observable<never> {
+    let errorMessage = '';
+    if (err.error instanceof ErrorEvent) {
+      // A client-side or network error occurred. Handle it accordingly.
+      errorMessage = err.error.message;
+    } else {
+      // The backend returned an unsuccessful response code.
+      // The response body may contain clues as to what went wrong,
+      errorMessage = `Backend returned code ${err.status}, body was: ${err.message}`;
+    }
+    return throwError(errorMessage);
+  }
+}

--- a/restitution-app/Controllers/ConfigurationController.cs
+++ b/restitution-app/Controllers/ConfigurationController.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Gov.Cscp.VictimServices.Public.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ConfigurationController : ControllerBase
+    {
+        private readonly ILogger<ConfigurationController> logger;
+        private readonly IConfiguration configuration;
+
+        public ConfigurationController(ILogger<ConfigurationController> logger, IConfiguration configuration)
+        {
+            this.logger = logger;
+            this.configuration = configuration;
+        }
+
+        [AllowAnonymous]
+        [HttpGet]
+        public IActionResult GetConfiguration()
+        {
+            try
+            {
+                var config = new Configuration
+                {
+                    OutageMessage = configuration.GetValue<string>("CONFIGURATION_OUTAGEINFORMATION_MESSAGE"),
+                    OutageStartDate = configuration.GetValue<string>("CONFIGURATION_OUTAGEINFORMATION_STARTDATE"),
+                    OutageEndDate = configuration.GetValue<string>("CONFIGURATION_OUTAGEINFORMATION_ENDDATE")
+                };
+
+                if (string.IsNullOrEmpty(config.OutageMessage) || string.IsNullOrEmpty(config.OutageStartDate) || string.IsNullOrEmpty(config.OutageEndDate))
+                {
+                    return Ok();
+                };
+
+                return Ok(config);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to retrieve configuration information.");
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+    }
+}
+
+public class Configuration
+{
+    public string OutageMessage { get; set; }
+    public string OutageStartDate { get; set; }
+    public string OutageEndDate { get; set; }
+};


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR removes the existing .NET 8 upgrade code for Restitution ahead of a major upgrade for Dynamics. It has not been approved to go out, and must be temporarily removed while an outage banner is pushed through to production.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules