### PR TITLE
VS-7213: Add empty-string to null converter to model.

### DIFF
--- a/restitution-app/Models/ModelUtils.cs
+++ b/restitution-app/Models/ModelUtils.cs
@@ -1,0 +1,43 @@
+using System;
+using Newtonsoft.Json;
+
+/// <summary>
+/// A JSON converter that converts empty strings to null values.
+/// </summary>
+/// /// <example>
+/// <code>
+/// [JsonConverter(typeof(EmptyStringToNullConverter))]
+/// public string? SomeProperty { get; set; }
+/// </code>
+/// </example>
+public class EmptyStringToNullConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(string);
+    }
+
+    public override object? ReadJson(
+        JsonReader reader,
+        Type objectType,
+        object? existingValue,
+        JsonSerializer serializer
+    )
+    {
+        var value = reader.Value as string;
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        var stringValue = value as string;
+        if (string.IsNullOrWhiteSpace(stringValue))
+        {
+            writer.WriteNull();
+        }
+        else
+        {
+            writer.WriteValue(stringValue);
+        }
+    }
+}

--- a/restitution-app/ViewModels/RestitutionFormModel.cs
+++ b/restitution-app/ViewModels/RestitutionFormModel.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 
 namespace Gov.Cscp.VictimServices.Public.ViewModels
 {
@@ -18,40 +19,68 @@ namespace Gov.Cscp.VictimServices.Public.ViewModels
         }
         public int vsd_applicanttype { get; set; }
         public string vsd_applicantsfirstname { get; set; }
-        public string vsd_applicantsmiddlename { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_applicantsmiddlename { get; set; }
         public string vsd_applicantslastname { get; set; }
-        public string vsd_otherfirstname { get; set; }
-        public string vsd_otherlastname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_otherfirstname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_otherlastname { get; set; }
         public int? vsd_applicantsgendercode { get; set; }
         public DateTime? vsd_applicantsbirthdate { get; set; }
         public int? vsd_indigenous { get; set; }
         public int? vsd_applicantspreferredmethodofcontact { get; set; }
         public int? vsd_smspreferred { get; set; }
-        public string vsd_applicantsprimaryphonenumber { get; set; }
-        public string vsd_applicantsalternatephonenumber { get; set; }
-        public string vsd_applicantsemail { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_applicantsprimaryphonenumber { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_applicantsalternatephonenumber { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_applicantsemail { get; set; }
         public string vsd_applicantsprimaryaddressline1 { get; set; }
-        public string vsd_applicantsprimaryaddressline2 { get; set; }
-        public string vsd_applicantsprimaryaddressline3 { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_applicantsprimaryaddressline2 { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_applicantsprimaryaddressline3 { get; set; }
         public string vsd_applicantsprimarycity { get; set; }
         public string vsd_applicantsprimaryprovince { get; set; }
         public string vsd_applicantsprimarypostalcode { get; set; }
         public string vsd_applicantsprimarycountry { get; set; }
-        public string vsd_cvap_offenderfirstname { get; set; }
-        public string vsd_cvap_offendermiddlename { get; set; }
-        public string vsd_cvap_offenderlastname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_cvap_offenderfirstname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_cvap_offendermiddlename { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_cvap_offenderlastname { get; set; }
         public int? vsd_voicemailoption { get; set; }
         public string vsd_applicantssignature { get; set; }
         public string vsd_declarationfullname { get; set; }
         public string vsd_signingofficertitle { get; set; }
         public DateTime? vsd_declarationdate { get; set; }
         public string vsd_contacttitle { get; set; }
-        public string vsd_offendercustodylocation { get; set; }
-        public string vsd_genderidentitytext { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_offendercustodylocation { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_genderidentitytext { get; set; }
         public int? vsd_primaryraceethnicity { get; set; }
         public string vsd_primaryraceethnicitytext { get; set; }
         public int? vsd_pronouns { get; set; }
-        public string vsd_pronountext { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_pronountext { get; set; }
     }
 
     public class CourtInfo
@@ -60,8 +89,12 @@ namespace Gov.Cscp.VictimServices.Public.ViewModels
         {
             get { return "Microsoft.Dynamics.CRM.vsd_applicationcourtinformation"; }
         }
-        public string vsd_courtfilenumber { get; set; }
-        public string vsd_courtlocation { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_courtfilenumber { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_courtlocation { get; set; }
     }
 
     public class Participant
@@ -70,10 +103,18 @@ namespace Gov.Cscp.VictimServices.Public.ViewModels
         {
             get { return "Microsoft.Dynamics.CRM.vsd_participant"; }
         }
-        public string vsd_firstname { get; set; }
-        public string vsd_middlename { get; set; }
-        public string vsd_lastname { get; set; }
-        public string vsd_preferredname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_firstname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_middlename { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_lastname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_preferredname { get; set; }
         public string vsd_companyname { get; set; }
         public string vsd_name { get; set; }
         public string vsd_addressline1 { get; set; }
@@ -85,15 +126,25 @@ namespace Gov.Cscp.VictimServices.Public.ViewModels
         public string vsd_postalcode { get; set; }
         public int? vsd_preferredmethodofcontact { get; set; }
         public int? vsd_restcontactpreferenceforupdates { get; set; }
-        public string vsd_phonenumber { get; set; }
-        public string vsd_alternatephonenumber { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_phonenumber { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_alternatephonenumber { get; set; }
         public int? vsd_voicemailoptions { get; set; }
-        public string vsd_email { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_email { get; set; }
         public string vsd_rest_custodylocation { get; set; }
-        public string vsd_rest_programname { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_rest_programname { get; set; }
         public string vsd_relationship1 { get; set; }
         public string vsd_relationship2 { get; set; }
-        public string vsd_relationship2other { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? vsd_relationship2other { get; set; }
         public string vsd_title { get; set; }
         public string vsd_contacttitle { get; set; }
         public int? vsd_smspreferred { get; set; }
@@ -105,6 +156,8 @@ namespace Gov.Cscp.VictimServices.Public.ViewModels
         public string fortunecookietype => "Microsoft.Dynamics.CRM.activitymimeattachment";
         public string filename { get; set; }
         public string body { get; set; }
-        public string subject { get; set; }
+
+        [JsonConverter(typeof(EmptyStringToNullConverter))]
+        public string? subject { get; set; }
     }
 }


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/VS-7213

## Changes

Add empty-string to null decorator to model. Ensures that optional string fields. whose value is an empty string, are converted to null before being serialized and sent to dynamics. Similar change to: https://github.com/bcgov/pssg-cscp-vsu/pull/105
