### PR TITLE
Enhance DataverseHealthCheck with logging for connectivity issues and…

### DIFF
--- a/restitution-app/HealthChecks/DataverseHealthCheck.cs
+++ b/restitution-app/HealthChecks/DataverseHealthCheck.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace Gov.Cscp.VictimServices.Public.HealthChecks
@@ -13,10 +14,15 @@ namespace Gov.Cscp.VictimServices.Public.HealthChecks
     public class DataverseHealthCheck : IHealthCheck
     {
         private readonly IOrganizationServiceAsync _organizationService;
+        private readonly ILogger<DataverseHealthCheck> _logger;
 
-        public DataverseHealthCheck(IOrganizationServiceAsync organizationService)
+        public DataverseHealthCheck(
+            IOrganizationServiceAsync organizationService,
+            ILogger<DataverseHealthCheck> logger
+        )
         {
             _organizationService = organizationService;
+            _logger = logger;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(
@@ -28,6 +34,11 @@ namespace Gov.Cscp.VictimServices.Public.HealthChecks
             {
                 if (_organizationService is ServiceClient serviceClient && !serviceClient.IsReady)
                 {
+                    _logger.LogError(
+                        "DataverseHealthCheck status={CheckStatus} description={CheckDescription}",
+                        HealthStatus.Unhealthy,
+                        "Dataverse ServiceClient is not ready."
+                    );
                     return HealthCheckResult.Unhealthy("Dataverse ServiceClient is not ready.");
                 }
 
@@ -37,6 +48,12 @@ namespace Gov.Cscp.VictimServices.Public.HealthChecks
             }
             catch (Exception ex)
             {
+                _logger.LogError(
+                    ex,
+                    "DataverseHealthCheck status={CheckStatus} description={CheckDescription}",
+                    HealthStatus.Unhealthy,
+                    "Dataverse health check failed."
+                );
                 return HealthCheckResult.Unhealthy("Dataverse health check failed.", exception: ex);
             }
         }

--- a/restitution-app/Program.cs
+++ b/restitution-app/Program.cs
@@ -160,17 +160,13 @@ app.UseSerilogRequestLogging(options =>
 
         var path = httpContext.Request.Path.ToString();
 
-        var logIgnoreEndpoints = new[] { "/hc", "/api/lookup" };
+        if (path.StartsWith("/hc", StringComparison.OrdinalIgnoreCase))
+            return httpContext.Response.StatusCode >= 500
+                ? Serilog.Events.LogEventLevel.Error
+                : Serilog.Events.LogEventLevel.Verbose;
 
-        if (
-            Array.Exists(
-                logIgnoreEndpoints,
-                e => path.StartsWith(e, StringComparison.OrdinalIgnoreCase)
-            )
-        )
-        {
+        if (path.StartsWith("/api/lookup", StringComparison.OrdinalIgnoreCase))
             return Serilog.Events.LogEventLevel.Verbose;
-        }
 
         return elapsed > 1000
             ? Serilog.Events.LogEventLevel.Warning


### PR DESCRIPTION
… exceptions

## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

:information_source: [**Jira Ticket Number here**](Jira web address here)  

This pull request enhances error logging for the Dataverse health check and refines the logging behavior for health check endpoints. The main improvements are the addition of structured logging for health check failures and more granular control over log levels for specific endpoints.

**Health check logging improvements:**

* Added an `ILogger<DataverseHealthCheck>` dependency to the `DataverseHealthCheck` class and now log errors when the Dataverse `ServiceClient` is not ready or when the health check fails, including exception details. [[1]](diffhunk://#diff-a06f3fe06cff759819e36f6a1843145c76916e70476e209c18696e8adff6f3e2R6) [[2]](diffhunk://#diff-a06f3fe06cff759819e36f6a1843145c76916e70476e209c18696e8adff6f3e2R17-R25) [[3]](diffhunk://#diff-a06f3fe06cff759819e36f6a1843145c76916e70476e209c18696e8adff6f3e2R37-R41) [[4]](diffhunk://#diff-a06f3fe06cff759819e36f6a1843145c76916e70476e209c18696e8adff6f3e2R51-R56)

**Log level handling for endpoints:**

* Updated the log level logic in `Program.cs` so that requests to `/hc` endpoints are logged as `Error` only if the response status code is 500 or higher, otherwise as `Verbose`. Requests to `/api/lookup` are always logged as `Verbose`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules