### PR TITLE
feat: implement outage alert component and logic for announcement banner

### DIFF
--- a/restitution-app/ClientApp/src/app/app.component.html
+++ b/restitution-app/ClientApp/src/app/app.component.html
@@ -20,15 +20,9 @@
     </header>
     <div>
       <main class="app-content">
-        <div class="app-main">
-          @if (!error && isOutage()) {
-            <div
-              class="text-center warning"
-              >
-              <h1 class="warning">Site Outage</h1>
-              <h2 class="warning"><b>{{ configuration.outageMessage }}</b></h2>
-              <h2 class="warning"><b>{{ generateOutageDateMessage() }}</b></h2>
-            </div>
+        <div class="app-main">          
+          @if (showAnnouncementBanner) {
+            <app-alert [message]="announcementMessage"></app-alert>
           }
           <breadcrumb></breadcrumb>
           <router-outlet></router-outlet>

--- a/restitution-app/ClientApp/src/app/app.component.ts
+++ b/restitution-app/ClientApp/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, isDevMode, OnInit, Renderer2 } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import moment from 'moment-timezone';
 import { environment } from '../environments/environment';
 import { Configuration } from './interfaces/configuration.interface';
 import { ConfigurationStore } from './store/configuration/configuration.store';
@@ -48,31 +47,18 @@ export class AppComponent implements OnInit {
     return !!this.configurationStore.error();
   }
 
+  get showAnnouncementBanner(): boolean {
+    return this.configurationStore.showAnnouncementBanner();
+  }
+
+  get announcementMessage(): string {
+    return this.configurationStore.configuration().outageMessage ?? '';
+  }
+
   ngOnInit(): void {
     if (this.configurationStore.error()) {
       console.error('Failed to fetch configuration:', this.configurationStore.error());
     }
-  }
-
-  isOutage() {
-    if (
-      !this.configuration ||
-      !this.configuration.outageEndDate ||
-      !this.configuration.outageStartDate ||
-      !this.configuration.outageMessage
-    ) {
-      return false;
-    }
-    const currentDate = moment().tz('America/Vancouver');
-    const outageStartDate = moment(this.configuration.outageStartDate).tz('America/Vancouver');
-    const outageEndDate = moment(this.configuration.outageEndDate).tz('America/Vancouver');
-    return currentDate.isBetween(outageStartDate, outageEndDate, null, '[]');
-  }
-
-  generateOutageDateMessage(): string {
-    const startDate = moment(this.configuration.outageStartDate).tz('America/Vancouver').format('MMMM Do YYYY, h:mm a');
-    const endDate = moment(this.configuration.outageEndDate).tz('America/Vancouver').format('MMMM Do YYYY, h:mm a');
-    return 'The system will be down for maintenance from ' + startDate + ' to ' + endDate;
   }
 
   isIE10orLower() {

--- a/restitution-app/ClientApp/src/app/app.module.ts
+++ b/restitution-app/ClientApp/src/app/app.module.ts
@@ -54,6 +54,7 @@ import { PhonePipe } from './pipes/phone.pipe';
 import { QuickExitComponent } from './quick-exit/quick-exit.component';
 import { RestitutionApplicationComponent } from './restitution-application/restitution-application.component';
 import { StateService } from './services/state.service';
+import { AlertComponent } from './shared/alert/alert.component';
 import { CancelApplicationDialog } from './shared/cancel-dialog/cancel-dialog.component';
 import { DateFieldComponent } from './shared/date-field/date-field.component';
 import { CancelDialog } from './shared/dialogs/cancel/cancel.dialog';
@@ -76,6 +77,7 @@ import { SignPadDialog } from './sign-dialog/sign-dialog.component';
 
 @NgModule({
   declarations: [
+    AlertComponent,
     RestitutionAddressComponent,
     AppComponent,
     BreadcrumbComponent,

--- a/restitution-app/ClientApp/src/app/shared/alert/alert.component.html
+++ b/restitution-app/ClientApp/src/app/shared/alert/alert.component.html
@@ -1,0 +1,16 @@
+@if (isVisible) {
+  <div class="alert-banner" role="alert" aria-live="polite">
+    <div class="alert-banner__content">
+      <span class="alert-banner__icon" aria-hidden="true">&#9888;</span>
+      <div class="alert-banner__text">{{ message }}</div>
+    </div>
+    <button
+      class="alert-banner__dismiss"
+      type="button"
+      (click)="dismiss()"
+      aria-label="Dismiss announcement"
+      title="Dismiss">
+      &times;
+    </button>
+  </div>
+}

--- a/restitution-app/ClientApp/src/app/shared/alert/alert.component.scss
+++ b/restitution-app/ClientApp/src/app/shared/alert/alert.component.scss
@@ -1,0 +1,52 @@
+.alert-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #f8bb47;
+  padding: 14px 30px;
+  margin: 16px 24px;
+  border-radius: 4px;
+  gap: 12px;
+
+  &__content {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+  }
+
+  &__icon {
+    font-size: 20px;
+    color: #2d2d2d;
+    flex-shrink: 0;
+    line-height: 1.4;
+  }
+
+  &__text {
+    color: #2d2d2d;
+    font-size: 15px;
+    line-height: 1.5;
+  }
+
+  &__dismiss {
+    background: none;
+    border: none;
+    font-size: 22px;
+    font-weight: bold;
+    color: #2d2d2d;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    flex-shrink: 0;
+    align-self: center;
+
+    &:hover {
+      color: #000;
+    }
+
+    &:focus {
+      outline: 2px solid #2d2d2d;
+      outline-offset: 2px;
+    }
+  }
+}

--- a/restitution-app/ClientApp/src/app/shared/alert/alert.component.ts
+++ b/restitution-app/ClientApp/src/app/shared/alert/alert.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html',
+  styleUrls: ['./alert.component.scss'],
+  standalone: false
+})
+export class AlertComponent {
+  @Input() message = '';
+  dismissed = false;
+
+  get isVisible(): boolean {
+    return !this.dismissed;
+  }
+
+  dismiss(): void {
+    this.dismissed = true;
+
+    // TODO: can be enhanced to pass event to parent component or service to handle dismissal state across the app if needed
+  }
+}

--- a/restitution-app/ClientApp/src/app/store/configuration/configuration.store.ts
+++ b/restitution-app/ClientApp/src/app/store/configuration/configuration.store.ts
@@ -1,4 +1,6 @@
-import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
+import { computed } from '@angular/core';
+import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
+import moment from 'moment-timezone';
 import { Configuration } from '../../interfaces/configuration.interface';
 
 export interface ConfigurationStoreState {
@@ -25,6 +27,16 @@ const initialState: ConfigurationStoreState = {
 export const ConfigurationStore = signalStore(
   { providedIn: 'root' },
   withState(initialState),
+  withComputed((store) => ({
+    showAnnouncementBanner: computed(() => {
+      const { outageMessage: message, outageStartDate: startDate, outageEndDate: endDate } = store.configuration();
+      if (!message || !startDate || !endDate) return false;
+      const current = moment().tz('America/Vancouver');
+      const start = moment(startDate).tz('America/Vancouver');
+      const end = moment(endDate).tz('America/Vancouver');
+      return current.isBetween(start, end, null, '[]');
+    })
+  })),
   withMethods((store) => ({
     setLoading(isConfigurationLoading: boolean) {
       patchState(store, { isConfigurationLoading });


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

:information_source: [**Jira Ticket Number here**](Jira web address here)  

This pull request refactors the site outage announcement logic to use a new reusable `AlertComponent` for displaying outage messages as a dismissible banner. The logic for determining when to show the banner is now centralized in the `ConfigurationStore`, improving maintainability and separation of concerns. The legacy outage display code has been removed from the main app component, and the new alert banner is styled and integrated throughout the app.

**Announcement Banner Refactor and UI Improvements:**

* Replaced the old outage message display in `app.component.html` with the new `<app-alert>` component, which shows a dismissible announcement banner when appropriate (`app.component.html`, `app.component.ts`). [[1]](diffhunk://#diff-4e2da86f43761c456e841be23bd83c85e5c8bf70af793c6dcc5748c778aae888L24-R25) [[2]](diffhunk://#diff-028d771a9a4e28d3f09a4f3d58afe5e6dfade4ecb1a89eeddefb2824a3ec3cd8L51-R61)
* Added a new `AlertComponent` with template, styles, and dismiss logic for displaying prominent alert banners (`alert.component.ts`, `alert.component.html`, `alert.component.scss`). [[1]](diffhunk://#diff-e41081f008ed5449d22f36dd96854a3b3a52233d3f789e5285ba9db05fd4b2c9R1-R22) [[2]](diffhunk://#diff-07e8cc9cf9f09142d548bb8da952aed2fcd691b129ef2bcaa8dca86167b7ea65R1-R16) [[3]](diffhunk://#diff-1a14e940788e47e3b56053821a9c6b7c80afa1f3d2654cf760d798a6eeaa499bR1-R52)
* Registered `AlertComponent` in the app module (`app.module.ts`). [[1]](diffhunk://#diff-44fdea5793296ed610f7ccdd7fe469e79bf30357a24516b8e1a7976503c6dac6R57) [[2]](diffhunk://#diff-44fdea5793296ed610f7ccdd7fe469e79bf30357a24516b8e1a7976503c6dac6R80)

**State Management Improvements:**

* Moved the logic for determining when to show the announcement banner into a computed property in `ConfigurationStore`, centralizing the logic and removing it from the main app component (`configuration.store.ts`). [[1]](diffhunk://#diff-e7417d5478bbe99ba0b95141a0647af8e68a8d3b02da0e8aed7d3922002d7141L1-R3) [[2]](diffhunk://#diff-e7417d5478bbe99ba0b95141a0647af8e68a8d3b02da0e8aed7d3922002d7141R30-R39)

**Code Cleanup:**

* Removed unused imports and legacy outage logic from `app.component.ts`. [[1]](diffhunk://#diff-028d771a9a4e28d3f09a4f3d58afe5e6dfade4ecb1a89eeddefb2824a3ec3cd8L3) [[2]](diffhunk://#diff-028d771a9a4e28d3f09a4f3d58afe5e6dfade4ecb1a89eeddefb2824a3ec3cd8L51-R61)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules